### PR TITLE
[CMS] Post: Locking Down VS Code Extensions in the Enterprise — Lessons from the GitHub Breach

### DIFF
--- a/_posts/2026-05-20-locking-down-vs-code-extensions-in-the-enterprise-lessons-from-the-github-breach.md
+++ b/_posts/2026-05-20-locking-down-vs-code-extensions-in-the-enterprise-lessons-from-the-github-breach.md
@@ -1,0 +1,285 @@
+---
+layout: post
+title: "Locking Down VS Code Extensions in the Enterprise — Lessons from the GitHub Breach"
+date: 2026-05-20 09:03:37 UTC
+category: security
+tags:
+  - security
+  - threatintel
+subtitle: "Secure your Dev"
+description: "How GitHub got breached via VS code malicious extensions, how to prevent it "
+image: https://res.cloudinary.com/hugs4bugs/image/upload/v1779268674/hugs4bugs/hacking-news/twitter-gh_jlkg9o.png
+optimized_image: https://res.cloudinary.com/hugs4bugs/image/upload/v1779268674/hugs4bugs/hacking-news/twitter-gh_jlkg9o.png
+image_position: "45% 8%"
+author: Shubhendu Shubham
+---
+
+**By a Security Architect who's tired of being surprised by developer endpoints**
+
+**May 20, 2026.** GitHub confirms that approximately 3,800 of its internal repositories were exfiltrated after a threat actor embedded malware inside a VS Code extension and a GitHub employee installed it. Critical secrets were rotated within hours. 
+
+![image](https://res.cloudinary.com/hugs4bugs/image/upload/v1779268674/hugs4bugs/hacking-news/twitter-gh_jlkg9o.png)
+[official GitHub Tweet](https://x.com/github/status/2056949168208552080)
+
+*This is not a vulnerability in GitHub's platform. This is a developer endpoint with unchecked tooling. And that is a far scarier problem.*
+
+## Why This Hit Different
+
+Every time I see a supply chain incident, I run a quick mental exercise: "Could this have happened to us?" With the GitHub breach, the answer in most organizations I've assessed is a quiet, uncomfortable *yes*.
+
+VS Code is installed on the vast majority of developer machines globally. It is trusted implicitly, it runs with the privileges of the logged-in user, it has full access to the file system, to the terminal, to environment variables and credential stores, and — critically — it auto-updates extensions by default. A compromised extension is not sandboxed in the traditional sense. It is a Node.js process running inside a trusted application, with the same access rights as the developer.
+
+The attack vector that hit GitHub was deceptively simple: a poisoned VS Code extension. No zero-day. No lateral movement through hardened infrastructure. Just a developer who installed something from what appeared to be a trustworthy channel. The payload then used the employee's existing credentials and developer tooling to reach internal repositories, turning the laptop into a bridge for exfiltration.
+
+This blog is about what every enterprise security team should have already had in place — and what you need to put in place now.
+
+## Understanding the Threat Model First
+
+Before throwing controls at a problem, let's be clear about what we're actually defending against.
+
+VS Code extensions run with **full IDE privileges**. Unlike browser extensions, which are sandboxed per the browser's process model, a VS Code extension inherits everything the IDE can do. That means:
+
+- Full read/write access to the local file system
+- Execution of arbitrary shell commands via the `child_process` module
+- Network egress with no built-in restrictions
+- Access to environment variables (which means AWS keys, GitHub tokens, API credentials stored in `.env` files)
+- Ability to hook into VS Code's startup routine, making the payload persistent across reboots
+
+The threat categories relevant to this class of attack are:
+
+**Typosquatting / Brandjacking** — Extensions with names nearly identical to popular tools. Recent documented examples include fake "prettier-vscode-plus" and "Icon Theme: Material" that cloned the legitimate extension to deliver Rust-based malware.
+
+**Trojanized updates** — A legitimate extension that gets compromised after it's already installed and trusted. Because VS Code auto-updates extensions by default, a malicious publisher update lands on all installed instances without user confirmation.
+
+**Dual-use extensions** — Extensions that deliver genuine, useful functionality while simultaneously stealing session cookies or exfiltrating credentials in the background. The Codo AI and Bitcoin Black extensions are documented examples of this pattern. This is the worst category because the user has zero reason to suspect foul play.
+
+**Compromised publisher accounts** — A threat actor gains access to a legitimate publisher's account and pushes a malicious update to an existing, trusted extension.
+
+The GitHub incident likely falls into one of the latter two categories, though the specific extension has not yet been publicly named. What we do know from GitHub's own statement is that the malicious version was removed from the marketplace promptly, which tells us it was likely a published extension rather than something installed from a `.vsix` file directly.
+
+
+## The Controls Framework — In Order of Impact
+
+I'm going to structure this the way I actually do it in architecture reviews: start with the highest-leverage controls and work down. Implementing all of these is ideal; implementing them in this order gives you the fastest risk reduction.
+
+
+### Control 1 — Enforce an Extension Allowlist via Group Policy (Non-Negotiable)
+
+This is the single most important control. VS Code v1.96 introduced the `extensions.allowed` setting, and it can be enforced centrally via the `AllowedExtensions` Group Policy so that the setting **overrides any user-configured value on managed devices**. This means even if a developer changes the setting locally, the policy wins at the machine level.
+
+The policy supports four levels of granularity:
+
+**By publisher (broadest):**
+```json
+{
+  "microsoft": true,
+  "github": true,
+  "*": false
+}
+```
+
+This allows all extensions published by Microsoft and GitHub and blocks everything else. The `"*": false` is the default-deny posture — without it, unlisted publishers are implicitly allowed.
+
+**By specific extension ID:**
+```json
+{
+  "esbenp.prettier-vscode": true,
+  "ms-python.python": true,
+  "dbaeumer.vscode-eslint": true,
+  "*": false
+}
+```
+
+**By pinned version (most restrictive):**
+```json
+{
+  "dbaeumer.vscode-eslint": ["3.0.0"],
+  "figma.figma-vscode-extension": ["3.0.0", "4.2.3"],
+  "rust-lang.rust-analyzer": ["5.0.0@win32-x64", "5.0.0@darwin-x64"]
+}
+```
+
+Version pinning is the strongest posture because it eliminates the trojanized update vector entirely. Even if a publisher's account is compromised and they push a malicious update, your fleet won't pull it. The tradeoff is operational overhead — you need a process to test and approve new versions before updating the pinned list.
+
+**Deploying the Policy**
+
+On **Windows** via Group Policy/Intune, starting from VS Code 1.69, each release ships with ADMX template files in the `policies` directory. Copy the `vscode.admx` and corresponding `ADML` files to the Group Policy Central Store, then configure the `AllowedExtensions` policy. To deploy programmatically via Intune remediation:
+
+```powershell
+# Intune remediation script — run as SYSTEM
+if (!(Test-Path "HKLM:\SOFTWARE\Policies\Microsoft\VSCode")) {
+    New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\VSCode" -Force -EA SilentlyContinue
+}
+
+$allowedExtensions = '{"microsoft": true, "github": true, "esbenp.prettier-vscode": true, "*": false}'
+
+New-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\VSCode" `
+    -Name "AllowedExtensions" `
+    -PropertyType String `
+    -Value $allowedExtensions `
+    -Force
+```
+
+> ⚠️ **Critical syntax note**: A space before `: true` in the JSON is required for the policy to be applied correctly. A syntax error in the policy value causes `extensions.allowed` to silently fail. Always check `Show Window Log` in VS Code after deploying to verify the policy is active. You'll see a lock icon next to the setting in the Settings editor when it's enforced.
+
+On **macOS**, deploy via MDM using a `.mobileconfig` configuration profile. Add the `AllowedExtensions` key under the VS Code payload:
+
+```xml
+<key>AllowedExtensions</key>
+<string>{"microsoft": true, "github": true, "*": false}</string>
+```
+
+On **Linux**, create the policy file at `/etc/vscode/policy.json` and deploy it via configuration management (Ansible, Puppet, Chef, Salt):
+
+```json
+{
+  "AllowedExtensions": {
+    "value": "{\"microsoft\": true, \"github\": true, \"*\": false}"
+  }
+}
+```
+
+When deployed and active, a developer attempting to install a blocked extension will see VS Code inform them the extension is not permitted. The setting in the preferences panel will show **"Managed by your organization"** with a lock icon.
+
+### Control 2 — Disable Auto-Updates for Extensions
+
+The trojanized update vector is real and underappreciated. VS Code auto-updates extensions by default. In the GitHub incident, if the malicious version was an update to an existing extension rather than a fresh install, auto-update would have delivered it to every machine with that extension installed — silently, at startup.
+
+Set the `UpdateMode` policy to `manual` or `none`:
+
+```json
+{
+  "UpdateMode": "manual"
+}
+```
+
+In `manual` mode, VS Code will inform users that updates are available but will not install them automatically. This gives security teams a window to review changelogs and validate updates before approving them.
+
+For environments with strict change control, set `UpdateMode` to `none` and manage VS Code updates entirely through your software deployment pipeline (e.g., Intune, SCCM, Munki).
+
+```powershell
+# Add alongside AllowedExtensions in the same registry key
+New-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\VSCode" `
+    -Name "UpdateMode" `
+    -PropertyType String `
+    -Value "manual" `
+    -Force
+```
+
+### Control 3 — Host a Private Extension Marketplace
+
+For organizations with GitHub Enterprise or Copilot Enterprise/Business accounts, Microsoft now offers a private marketplace capability. This allows you to:
+
+- Rehost curated public extensions after applying your own verification and security standards
+- Host internally developed extensions without publishing them to the public marketplace
+- Centrally control which extensions are searchable and installable by your developers
+- Deploy and manage the marketplace as a stateless Docker container with flexible storage (file system or Azure Artifacts)
+- Roll out to your team using group policy on Windows and macOS
+
+When a private marketplace is configured, developers search and install extensions directly from VS Code — the experience is identical to the public marketplace — but only extensions that have been approved and hosted internally are discoverable.
+
+This approach addresses the typosquatting vector completely. A developer cannot accidentally install `esbenp.prettier-vscod` (one character off) if only the legitimate `esbenp.prettier-vscode` exists in your private registry.
+
+For air-gapped or highly restricted environments (government, finance, defence), the private marketplace also supports full offline operation, which eliminates the network egress risk from extensions reaching out to external command-and-control infrastructure.
+
+### Control 4 — Lock Down Extension Installation Sources
+
+Block direct `.vsix` file installation. This is a gap that allowlists alone don't cover — if a developer can drag-and-drop a `.vsix` file into VS Code or use `code --install-extension malicious.vsix`, the publisher allowlist doesn't help.
+
+VS Code doesn't currently expose a direct policy for blocking `.vsix` installations, so this needs to be enforced at the endpoint level:
+
+- Use **AppLocker** or **Windows Defender Application Control (WDAC)** to prevent execution of arbitrary Node.js code from outside approved paths
+- Monitor for `code --install-extension` command-line invocations via EDR telemetry
+- Consider blocking the `code` CLI's ability to install extensions through endpoint DLP rules if your use case permits
+
+Additionally, block access to `marketplace.visualstudio.com` and `open-vsx.org` at the proxy/firewall layer if you are running a private marketplace, forcing all extension installs to route through your controlled registry.
+
+VS Code requires network access to the marketplace. If you restrict this at the network layer, ensure the following hostnames are either blocked (if using a private marketplace) or allowlisted (if using the public marketplace with extension allowlists):
+
+- `marketplace.visualstudio.com`
+- `*.gallery.vsassets.io`
+- `*.gallerycdn.vsassets.io`
+- `update.code.visualstudio.com` (for VS Code core updates)
+
+### Control 5 — Workspace Trust
+
+VS Code has a Workspace Trust model that restricts certain extension features when working in untrusted folders. When Workspace Trust is enabled, extensions that declare they require trust to run their full feature set will operate in a restricted mode until the developer explicitly trusts the workspace.
+
+This is not a primary control against malicious extensions (a sufficiently motivated malicious extension can declare itself as not requiring trust for its malicious payload), but it adds a layer of friction and visibility. You can enforce it centrally:
+
+```json
+{
+  "security.workspace.trust.enabled": true,
+  "security.workspace.trust.untrustedFiles": "open"
+}
+```
+
+More importantly, educate developers on what Workspace Trust means. An extension operating with reduced capabilities in an untrusted workspace is VS Code's way of surfacing that it has access to sensitive features. Developers who understand this will treat trust prompts with appropriate skepticism rather than clicking through them.
+
+### Control 6 — Secret Scanning and Pre-commit Hooks (Defense-in-Depth)
+
+The GitHub incident's downstream impact was repository exfiltration because internal repositories contained secrets. This is the second control surface that needs hardening — not the extension itself, but what's accessible once an endpoint is compromised.
+
+If secrets live in repositories, a compromised developer endpoint becomes a critical breach. A poisoned extension with access to the developer's Git credentials can exfiltrate every repository the developer has cloned or has access to via stored tokens.
+
+Mitigations:
+
+**Eliminate secrets from repositories entirely.** Use secret scanning with push protection enabled at the GitHub organization level. GitHub's push protection blocks commits containing detected secrets before they reach the remote. This should be mandatory for all internal repositories, not optional.
+
+**Rotate credentials on a schedule.** GitHub tokens, AWS access keys, and API keys should have short TTLs. A 90-day rotation cycle significantly reduces the blast radius of any credential that was present in a repository at the time of exfiltration.
+
+**Use Workload Identity Federation where possible.** Replace long-lived credentials with short-lived tokens issued via OIDC from your CI/CD platform. A stolen token that expires in 15 minutes is far less useful than one that's valid for a year.
+
+**Deploy a secrets manager.** Developer environments should pull secrets from HashiCorp Vault, AWS Secrets Manager, or Azure Key Vault at runtime rather than storing them in `.env` files on disk. An extension that can read `~/.aws/credentials` or a local `.env` file has effectively compromised every service those credentials grant access to.
+
+### Control 7 — EDR Monitoring on Developer Endpoints
+
+Developer endpoints are often treated as trusted to a degree that production servers are not, because developers need flexibility and elevated access to do their jobs. This is a category error that the GitHub incident illustrates clearly.
+
+Apply the same EDR monitoring stance to developer machines that you apply to servers. Specifically:
+
+- Monitor for VS Code extension directories spawning child processes (a legitimate linter doesn't need to launch `cmd.exe` or `bash -c curl ...`)
+- Alert on unusual outbound network connections from VS Code's extension host process (`extensionHostProcess.js`)
+- Monitor for credential file access patterns — extensions reading `~/.ssh/`, `~/.aws/`, `~/.gitconfig`, or local token stores should generate an alert if the extension ID is not in your approved list
+- Log all `git clone`, `git push`, and `git fetch` operations that originate from the developer's session, particularly to external hosts
+
+Most modern EDR platforms (CrowdStrike Falcon, SentinelOne, Microsoft Defender for Endpoint) can be configured to generate telemetry at this level of process granularity. The signal is there — the question is whether someone is watching it.
+
+## Putting It Together — A Practical Rollout Sequence
+
+If you're reading this and realizing your organization has none of these controls in place, here's the order I would recommend:
+
+**Week 1 — Immediate:** Deploy the `AllowedExtensions` policy in audit mode (log blocked installs but don't enforce yet). Run `Developer: Export Extension Account Access Report` to enumerate what extensions currently have access to developer accounts. This gives you visibility into your exposure without breaking developer workflows.
+
+**Week 2-3 — Build the approved list:** Work with your engineering leads to compile a list of extensions that are genuinely required for work. Be strict. Every extension on that list is attack surface. Aim for fewer than 20. Pin versions where possible.
+
+**Week 4 — Enforce the allowlist:** Switch from audit mode to enforcement. Communicate clearly to developers why this is happening. Provide a fast-track process for requesting addition of new extensions (with a security review step).
+
+**Week 4-6 — Disable auto-updates:** Set `UpdateMode` to `manual`. Establish a monthly review cadence for approved extension updates, with changelog review as a minimum gate.
+
+**Month 2 — Private marketplace (if applicable):** If you have GitHub Enterprise, begin the private marketplace rollout. Migrate your approved extensions list into the private registry. Block public marketplace access at the network layer once migration is complete.
+
+**Ongoing:** Rotate all developer credentials that could have been exposed. Enforce secret scanning with push protection. Begin the conversation about short-lived credentials and secrets manager adoption.
+
+## What This Incident Tells Us About Where We Are
+
+The GitHub breach is significant not because it broke new technical ground but because of who it happened to. GitHub is a security-aware company. Their engineers are not naive users who click phishing links without thinking. They are sophisticated developers who installed what appeared to be a legitimate VS Code extension from a trusted channel — and that was enough.
+
+The fundamental problem is that the developer tooling ecosystem operates on implicit trust. The VS Code marketplace runs security checks, but as independent research has demonstrated repeatedly, a sufficiently crafted extension can pass those checks while carrying a payload that only activates under specific conditions, or that delivers its malicious behavior through a later update. Verified Publisher badges verify domain ownership, not code integrity.
+
+The shift we need to make as an industry is treating the developer environment with the same rigor we apply to production infrastructure. Developer machines are in many ways more sensitive than production servers — they contain every secret the developer has ever touched, they have broad network access, and they sit at the origin of the software supply chain. A compromised developer endpoint is a compromised pipeline.
+
+The controls in this post are not exotic. They are documented, supported by Microsoft's official tooling, and deployable today. What they require is organizational will to prioritize the developer endpoint as a security boundary, and that will needs to come from this incident.
+
+## References
+
+- VS Code Enterprise Extension Management: https://code.visualstudio.com/docs/enterprise/extensions
+- VS Code Enterprise Policies Reference: https://code.visualstudio.com/docs/enterprise/policies
+- VS Code Update Management: https://code.visualstudio.com/docs/enterprise/updates
+- VS Code for Enterprise Overview: https://code.visualstudio.com/docs/enterprise/overview
+- VS Code Extension Runtime Security: https://code.visualstudio.com/docs/configure/extensions/extension-runtime-security
+- GitHub Security Advisory (official X thread, May 20, 2026): https://twitter.com/github
+- GitHub Push Protection (Secret Scanning): https://docs.github.com/en/code-security/secret-scanning/push-protection-for-repositories-and-organizations
+
+
+*Written from the field, after one too many post-incident reviews where the root cause turned out to be a developer's laptop.*


### PR DESCRIPTION
Auto-generated by hugs4bugs CMS.

**Ready to publish - auto-merging.**